### PR TITLE
Fix ESP::reset() return string in newer firmware

### DIFF
--- a/espduino.cpp
+++ b/espduino.cpp
@@ -361,7 +361,7 @@ void ESP::disable()
 
 BOOL ESP::reset()
 {
-  return exec("AT+RST", "\r\nready\r\n", 5000);
+  return exec("AT+RST", "[System Ready, Vendor:www.ai-thinker.com]", 5000);
 }
 
 


### PR DESCRIPTION
On the new firmware (v0.9.2.2 but some fw before too) the "ready" changed...