### PR TITLE
Update include guard for REST class.

### DIFF
--- a/espduino/rest.h
+++ b/espduino/rest.h
@@ -4,8 +4,8 @@
  * \author
  *       Tuan PM <tuanpm@live.com>
  */
-#ifndef _MQTT_H_
-#define _MQTT_H_
+#ifndef _REST_H_
+#define _REST_H_
 
 #include <stdint.h>
 #include <Arduino.h>


### PR DESCRIPTION
I'm not sure if it was intentional to have the include guard for REST class as MQTT. However, I need to corrected the one in rest.h in order to be able to include both rest.h and mqtt.h in the same file.